### PR TITLE
Fix typo with config filename

### DIFF
--- a/slackbotExercise.py
+++ b/slackbotExercise.py
@@ -1,3 +1,4 @@
+s
 import random
 import time
 import requests
@@ -51,7 +52,7 @@ class Bot:
     '''
     def setConfiguration(self):
         # Read variables fromt the configuration file
-        with open('config.json') as f:
+        with open('default.json') as f:
             settings = json.load(f)
 
             self.team_domain = settings["teamDomain"]


### PR DESCRIPTION
The current script won't work because the config json file is named default.json and not config.json
