### PR TITLE
Add support for office hours

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,8 +4,9 @@
   "channelId": "channelIdHere",
 
   "officeHours": {
-    "begin": 10,
-    "end": 16
+    "on": false,
+    "begin": 9,
+    "end": 17
    },
 
   "debug": false,

--- a/default.json
+++ b/default.json
@@ -3,6 +3,11 @@
   "channelName": "general",
   "channelId": "channelIdHere",
 
+  "officeHours": {
+    "begin": 10,
+    "end": 16
+   },
+
   "debug": false,
 
   "callouts": {

--- a/slackbotExercise.py
+++ b/slackbotExercise.py
@@ -7,8 +7,7 @@ import os
 from random import shuffle
 import pickle
 import os.path
-import time
-from datetime import datetime
+import datetime
 
 from User import User
 
@@ -63,6 +62,8 @@ class Bot:
             self.group_callout_chance = settings["callouts"]["groupCalloutChance"]
             self.channel_id = settings["channelId"]
             self.exercises = settings["exercises"]
+            self.office_hours_begin = settings["officeHours"]["begin"]
+            self.office_hours_end = settings["officeHours"]["end"]
 
             self.debug = settings["debug"]
 
@@ -227,7 +228,7 @@ def logExercise(bot,username,exercise,reps,units):
     with open(filename, 'a') as f:
         writer = csv.writer(f)
 
-        writer.writerow([str(datetime.now()),username,exercise,reps,units,bot.debug])
+        writer.writerow([str(datetime.datetime.now()),username,exercise,reps,units,bot.debug])
 
 def saveUsers(bot):
     # Write to the command console today's breakdown
@@ -248,7 +249,7 @@ def saveUsers(bot):
                 s += str(0).ljust(len(exercise["name"]) + 2)
         s += "\n"
 
-        user.storeSession(str(datetime.now()))
+        user.storeSession(str(datetime.datetime.now()))
 
     s += "```"
 
@@ -261,20 +262,34 @@ def saveUsers(bot):
     with open('user_cache.save','wb') as f:
         pickle.dump(bot.user_cache,f)
 
+def isOfficeHours(bot):
+    now = datetime.datetime.now()
+    now_time = now.time()
+    if now_time >= datetime.time(bot.office_hours_begin) and now_time <= datetime.time(bot.office_hours_end):
+        return True
+    else:
+        return False;
 
 def main():
     bot = Bot()
 
     try:
         while True:
-            # Re-fetch config file if settings have changed
-            bot.setConfiguration()
+            if isOfficeHours(bot):
+                # Re-fetch config file if settings have changed
+                bot.setConfiguration()
 
-            # Get an exercise to do
-            exercise = selectExerciseAndStartTime(bot)
+                # Get an exercise to do
+                exercise = selectExerciseAndStartTime(bot)
 
-            # Assign the exercise to someone
-            assignExercise(bot, exercise)
+                # Assign the exercise to someone
+                assignExercise(bot, exercise)
+
+            else:
+                # Sleep and check again for office hours
+                time.sleep(5*60) # Sleep 5 minutes
+
+
     except KeyboardInterrupt:
         saveUsers(bot)
 


### PR DESCRIPTION
Set the times the bot should be running in config.json.

Right now this is very simple and only supports whole hours and doesn't
check if the last challenge of the day is outside office hours.

Fixes #17 
