### PR TITLE
Include a Dockerfile and change configuration strategy to use a JSON file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:2.7.10-onbuild
+MAINTAINER Robert Ross <robert@creativequeries.com>
+
+CMD ["python", "./slackbotExercise.py"]
+
+RUN mkdir -p /slackbot
+
+# A small protection against building a container with credentials inside of it
+# Just remove the config if it gets added to the container.
+RUN rm ./config.json || true

--- a/README.md
+++ b/README.md
@@ -67,9 +67,12 @@ This container expects a config file somewhere in its file system. The easiest
 way to do this, is to mount a directory on the host, inside of the container. We
 do this using the `-v` flag when running the container.
 
-The example we give is `-v ".:/slackbot"`, Where `.` is the current direcotry
+The example we give is `-v "$PWD:/slackbot"`, Where `$PWD` is the current direcotry
 you're mounting. Just make sure you have a JSON config file in it.
 
+After that, you'll need to set an environment variable when running the
+container to point to the configuration file.
+
 ```sh
-$ docker run -t -v ".:/slackbot" -e "CONFIG_FILE=/slackbot/config.json" slackbots/exercise
+$ docker run -t -v "$PWD:/slackbot" -e "CONFIG_FILE=/slackbot/config.json" slackbots/exercise
 ```

--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ A fun hack that gets Slackbot to force your teammates to work out!
 
     <img src="https://ctrlla-blog.s3.amazonaws.com/2015/Jun/Screen_Shot_2015_06_03_at_8_44_00_AM-1433557565175.png" width = 500>
 
-6. Save your SLACK_USER_TOKEN_STRING and SLACK_URL_TOKEN_STRING as environmental variables in your terminal.
+6. Copy the `default.json` file to `config.json` ( `cp default.json config.json` )
 
-    `$ export SLACK_USER_TOKEN_STRING=YOURUSERTOKEN`
+6. Save your user token and url token in the `config.json` file you just copied.
 
-    `$ export SLACK_URL_TOKEN_STRING=YOURURLTOKEN`
 
-    Open `default.json` and set `teamDomain` (ex: ctrlla) `channelName` (ex: general) and `channelId` (ex: B22D35YMS). Save the file as `config.json` in the same directory. Set any other configurations as you like.
+    Open `config.json` and set `teamDomain` (ex: ctrlla) `channelName` (ex: general) and `channelId` (ex: B22D35YMS).
+    Set any other configurations as you like.
 
     If you don't know the channel Id, fetch it using
 

--- a/README.md
+++ b/README.md
@@ -48,3 +48,28 @@ A fun hack that gets Slackbot to force your teammates to work out!
     `$ python slackbotExercise.py`
 
 Run the script to start the workouts and hit ctrl+c to stop the script. Hope you have fun with it!
+
+## Docker
+
+This project includes a Dockerfile that will run the python script within a container.
+
+To run the Docker container, follow these steps:
+
+#### Pull the container
+
+```sh
+$ docker pull slackbots/exercise
+```
+
+#### Run the container
+
+This container expects a config file somewhere in its file system. The easiest
+way to do this, is to mount a directory on the host, inside of the container. We
+do this using the `-v` flag when running the container.
+
+The example we give is `-v ".:/slackbot"`, Where `.` is the current direcotry
+you're mounting. Just make sure you have a JSON config file in it.
+
+```sh
+$ docker run -t -v ".:/slackbot" -e "CONFIG_FILE=/slackbot/config.json" slackbots/exercise
+```

--- a/User.py
+++ b/User.py
@@ -4,7 +4,16 @@ import json
 import datetime
 
 # Environment variables must be set with your tokens
-USER_TOKEN_STRING =  os.environ['SLACK_USER_TOKEN_STRING']
+CONFIG_FILE_STRING = os.environ['CONFIG_FILE']
+USER_TOKEN_STRING = ''
+URL_TOKEN_STRING = ''
+
+HASH = "%23"
+
+with open(CONFIG_FILE_STRING) as f:
+    settings = json.load(f)
+    USER_TOKEN_STRING = settings['userToken']
+    URL_TOKEN_STRING = settings['urlToken']
 
 class User:
 

--- a/default.json
+++ b/default.json
@@ -1,7 +1,9 @@
 {
   "teamDomain": "yourDomainHere",
-  "channelName": "general",
-  "channelId": "channelIdHere",
+  "channelName": "exercise",
+  "channelId": "",
+  "userToken": "",
+  "urlToken": "",
 
   "officeHours": {
     "on": false,

--- a/results.csv
+++ b/results.csv
@@ -1,9 +1,0 @@
-@bshin,26, SECOND PLANK 
-@shahan,45, PUSHUPS 
-@shahan,42, SECOND WALL SIT 
-@bshin,26, PUSHUPS 
-@bshin,35, PUSHUPS 
-@bshin,28, PUSHUPS 
-@shahan,40, SECOND PLANK 
-@brandon,48, PUSHUPS 
-@bshin,36, SECOND WALL SIT 

--- a/slackbotExercise.py
+++ b/slackbotExercise.py
@@ -12,11 +12,16 @@ import datetime
 from User import User
 
 # Environment variables must be set with your tokens
-USER_TOKEN_STRING =  os.environ['SLACK_USER_TOKEN_STRING']
-URL_TOKEN_STRING =  os.environ['SLACK_URL_TOKEN_STRING']
+CONFIG_FILE_STRING = os.environ['CONFIG_FILE']
+USER_TOKEN_STRING = ''
+URL_TOKEN_STRING = ''
 
 HASH = "%23"
 
+with open(CONFIG_FILE_STRING) as f:
+    settings = json.load(f)
+    USER_TOKEN_STRING = settings['userToken']
+    URL_TOKEN_STRING = settings['urlToken']
 
 # Configuration values to be set in setConfiguration
 class Bot:
@@ -50,7 +55,7 @@ class Bot:
     '''
     def setConfiguration(self):
         # Read variables fromt the configuration file
-        with open('config.json') as f:
+        with open(CONFIG_FILE_STRING) as f:
             settings = json.load(f)
 
             self.team_domain = settings["teamDomain"]
@@ -221,7 +226,7 @@ def assignExercise(bot, exercise):
 
     # Announce the user
     if not bot.debug:
-        requests.post(bot.post_URL, data=winner_announcement)
+        response = requests.post(bot.post_URL, data=winner_announcement)
     print winner_announcement
 
 


### PR DESCRIPTION
This changes around how configuration is loaded, pulling from the JSON file for everything.

This is done to enable Docker containerization easily. By mounting a config.json file in the container on start, and setting an ENV variable pointing to that file. We can easily load in configuration to the container on start.

We're using this fork at Namely right now and it's working great. Super easy to deploy.

@brandonshin - I'm happy to add you to the slackbots docker organization on hub.docker.com
