### PR TITLE
add signoff message at end of office hours

### DIFF
--- a/default.json
+++ b/default.json
@@ -6,7 +6,8 @@
   "officeHours": {
     "on": false,
     "begin": 9,
-    "end": 17
+    "end": 17,
+    "signoffMessage": "Great workout today, team! Rest up for our next session."
    },
 
   "debug": false,


### PR DESCRIPTION
When using office hours, the bot posts the final challenge to the channel even though it may fall outside the office hours window. This patch first checks to see if the next challenge will occur within the posted office hours and if not instead prints a final message signaling the end to the day's workout activities.
