### PR TITLE
Set default encoding to utf-8

### DIFF
--- a/slackbotExercise.py
+++ b/slackbotExercise.py
@@ -9,6 +9,10 @@ import pickle
 import os.path
 import datetime
 
+import sys
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
 from User import User
 
 # Environment variables must be set with your tokens


### PR DESCRIPTION
Without this, fetchActiveUsers will silently fail if usernames contain non-ascii characters.
```
File "/usr/src/slackbot-workout/User.py", line 30, in __init__
   print "New user: " + self.real_name + " (" + self.username + ")"
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0161' in position 23: ordinal not in range(128)
```
This will cause the bot to never choose a winner for the current exercise.
```
slackbot [15:06] 
NEXT LOTTERY FOR PLANKS IS IN 19 MINUTES
slackbot [15:25] 
NEXT LOTTERY FOR CHAIR DIPS IS IN 22 MINUTES
```